### PR TITLE
Remove compilation bottleneck for Swift 5.3.2 builds (#147)

### DIFF
--- a/Sources/Algorithms/Stride.swift
+++ b/Sources/Algorithms/Stride.swift
@@ -226,9 +226,15 @@ extension StrideCollection: Collection {
     offsetBy n: Int,
     limitedBy limit: Index
   ) -> Index? {
-    let distance = i == endIndex
-      ? -((base.count - 1) % stride + 1) + (n - 1) * -stride
-      : n * -stride
+    // We typically use the ternary operator but this significantly increases
+    // compile times when using Swift 5.3.2
+    // https://github.com/apple/swift-algorithms/issues/146
+    let distance: Int
+    if i == endIndex {
+      distance = -((base.count - 1) % stride + 1) + (n - 1) * -stride
+    } else {
+      distance = n * -stride
+    }
     return base.index(
         i.base,
         offsetBy: distance,


### PR DESCRIPTION
Benchmarks on Xcode 12.4 showed compiling / type checking
StrideCollection.offsetBackward was the bottleneck for building
the package. Replacing the ternary operator in that function
with an explicit if/else removes the bottleneck.

<!--
    Thanks for contributing to Swift Algorithms!

    If this pull request adds new API, please add '?template=new.md'
    to the URL to switch to the appropriate template.

    Before you submit your request, please replace the paragraph
    below with the relevant details, and complete the steps in the
    checklist by placing an 'x' in each box:
    
    - [x] I've completed this task
    - [ ] This task isn't completed
-->

Replace this paragraph with a description of your changes and rationale. Provide links to an existing issue or external references/discussions, if appropriate.

### Checklist
- [ ] I've added at least one test that validates that my change is working, if appropriate
- [ ] I've followed the code style of the rest of the project
- [ ] I've read the [Contribution Guidelines](../blob/main/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary
